### PR TITLE
DEVOPS-269 Fixed: "WARNING - No resources available".

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ checkhealth [-h] -U URL [-v] [-t TIMEOUT] [-u USERNAME]
 
 optional arguments:
   -h, --help            show this help message and exit
-  -U URL, --url URL
-                        Agora's url
+  -U URL, --url URL     Agora's url
   -v, --verbose         verbose output
+  -l, --listview        check if the listViews have records
   -t TIMEOUT, --timeout TIMEOUT
                         timeout for requests, default=180
   -u USERNAME, --username USERNAME
@@ -58,9 +58,16 @@ After installing requirements.txt, you can run the tests from the project direct
 $ python -m unittest discover
 ```
 
+
+## Tested.
+Tested in the following Python versions:
+* [X] Python 2.7
+* [X] Python 3.5.3
+
+
 ## Copyright and license
 
-Copyright (C) 2018 GRNET S.A.
+Copyright (C) 2018-2020 GRNET S.A.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as


### PR DESCRIPTION
It is no longer checked by default whether or not there are resources in the listView. 
Now the parameter `-l` must be added to perform this check.

* [X] Removed unnecessary function `check_endpoint`.
* [X] Tested with Python **3.5.3**

Tests :construction: 
==================

* [X] Agora instance with resources.
```bash
python modules/checkhealth.py -U test0.agora.grnet.gr -u "*****" -p "*****"
```
<details>
  <summary>Output</summary>

```output
...../lib/python3.5/site-packages/urllib3/connectionpool.py:988: InsecureRequestWarning: Unverified HTTPS request is being made to host 'testvm.agora.grnet.gr'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,

...../lib/python3.5/site-packages/urllib3/connectionpool.py:988: InsecureRequestWarning: Unverified HTTPS request is being made to host 'testvm.agora.grnet.gr'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,

OK - Agora is up.
```
</details>


* [X] Agora instance with no resources available ( without `-l`) 
```bash
python modules/checkhealth.py -U test1.agora.grnet.gr -u "*****" -p "*****" -v -i
```

<details>
  <summary>Output</summary>

```output
OK - Agora is up.
```
</details>


* [X] Agora instance with no resources available
```bash
python modules/checkhealth.py -U test1.agora.grnet.gr -u "*****" -p "*****" -v -i -l
```

<details>
  <summary>Output</summary>

```output
WARNING - No resources available.[].
```
</details>