### PR TITLE
Parameter -U  changed to  -H

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ $ python setup.py install
 
 ## Usage
 ```
-checkhealth [-h] -U URL [-v] [-t TIMEOUT] [-u USERNAME]
+checkhealth [-h] -H Hostname [-v] [-t TIMEOUT] [-u USERNAME]
             [-p PASSWORD] [-i]
 
 
 optional arguments:
   -h, --help            show this help message and exit
-  -U URL, --url URL     Agora's url
+  -H Hostname, --hostname Hostname     Agora's hostname
   -v, --verbose         verbose output
   -l, --listview        check if the listViews have records
   -t TIMEOUT, --timeout TIMEOUT

--- a/modules/checkhealth.py
+++ b/modules/checkhealth.py
@@ -28,7 +28,7 @@ class AgoraHealthCheck:
                     'password': self.args.password,
         }
 
-        login_url = 'https://{0}/{1}'.format(self.args.url, self.LOGIN_PATH)
+        login_url = 'https://{0}/{1}'.format(self.args.hostname, self.LOGIN_PATH)
         
         login_resp = requests.post(url=login_url, data=json.dumps(payload), headers=self.HEADERS, verify=self.args.ignore_ssl, timeout=self.args.timeout)
 
@@ -51,7 +51,7 @@ class AgoraHealthCheck:
 
     def check_resources(self):
         self.HEADERS['Authorization'] = 'Token {}'.format(self.token)
-        resources_url = 'https://{0}/{1}'.format(self.args.url, self.RESOURCES_PATH)
+        resources_url = 'https://{0}/{1}'.format(self.args.hostname, self.RESOURCES_PATH)
 
         resources_resp = requests.get(url=resources_url, headers=self.HEADERS, verify=self.args.ignore_ssl, timeout=self.args.timeout)
 
@@ -83,8 +83,8 @@ class AgoraHealthCheck:
 
 def parse_arguments(args):
     parser = argparse.ArgumentParser(description="Nagios Probe for Agora")
-    parser.add_argument('-U', '--url', dest='url', required=True,
-                        type=str, help='Agora\'s url')
+    parser.add_argument('-H', '--hostname', dest='hostname', required=True,
+                        type=str, help='Agora\'s hostname')
     parser.add_argument('-v', '--verbose', dest='verbose',
                         action='store_true', help='verbose output')
     parser.add_argument('-l', '--listview', dest='listview_check',


### PR DESCRIPTION
* [X] The argument `-U` changed to `-H`.

Tests :construction: 
==================

```bash
python modules/checkhealth.py -H test1.agora.grnet.gr -u "*****" -p "*****" -v -i
```

<details>
  <summary>Output</summary>

```output
OK - Agora is up.
```
</details>


Warning :warning: 
==================
There is no backward compatibility. The old parameter (`-U`) is no longer supported.

```bash
python modules/checkhealth.py -U test1.agora.grnet.gr -u "*****" -p "*****" -v -i
```

<details>
  <summary>Output</summary>

```output
usage: checkhealth.py [-h] -H HOSTNAME [-v] [-l] [-t TIMEOUT] [-u USERNAME]
                      [-p PASSWORD] [-i]
checkhealth.py: error: the following arguments are required: -H/--hostname
```
</details>
